### PR TITLE
Fix toLatex.ftable() with extrarowsep

### DIFF
--- a/pkg/R/tolatex-ftable.R
+++ b/pkg/R/tolatex-ftable.R
@@ -149,8 +149,7 @@ toLatex.ftable <- function(object,
     rowsep <- rep("\\\\",NROW(body))
     .extrarowsep <- rep("",NROW(body))
     lrv <- length(row.vars[[n.row.vars]])
-    ii <- seq(NROW(body)%/%lrv)*lrv
-    if(show.titles && length(names(row.vars))) ii <- ii+1
+    ii <- seq(NROW(body)%/%lrv-1)*lrv
     .extrarowsep[ii] <- paste("[",extrarowsep,"]",sep="")
     rowsep <- paste(rowsep,.extrarowsep,sep="")
     body <- paste(body,rowsep,sep="")


### PR DESCRIPTION
Fixed computation of indexes where the extra row separator is inserted.

Fixes #9.