### PR TITLE
Add 'format_md()' S3-generic function to format codebook to Markdown

### DIFF
--- a/pkg/NAMESPACE
+++ b/pkg/NAMESPACE
@@ -505,3 +505,7 @@ S3method(format,item.vector)
 importFrom(yaml,as.yaml,read_yaml,write_yaml)
 importFrom(jsonlite,read_json,write_json)
 export(read_codeplan,write_codeplan)
+
+export(format_md)
+S3method(format_md, codebook)
+S3method(format_md, codebookEntry)

--- a/pkg/R/AllGenerics.R
+++ b/pkg/R/AllGenerics.R
@@ -70,3 +70,7 @@ setGeneric("codeplan",
 setGeneric("setCodeplan",function(x,value)
   standardGeneric("setCodeplan"))
 
+format_md <- function(x, ...) {
+  UseMethod("format_md")
+}
+

--- a/pkg/R/codebook-format-md.R
+++ b/pkg/R/codebook-format-md.R
@@ -1,0 +1,63 @@
+format_md.codebook <- function(x, unlist = TRUE, collapse = TRUE, ...) {
+  output <- mapply(format_md, x = x@.Data, name = names(x),
+                   MoreArgs = list(...))
+  names(output) <- names(x)
+  if (unlist) output <- unlist(output)
+  if (collapse && is.list(output)) {
+    output <- lapply(output, paste, collapse = "\n\n")
+    output <- lapply(output, gsub, 
+                     pattern = "|\n\n", replacement = "|\n", fixed = TRUE)
+  }
+  if (collapse && !is.list(output)) {
+    output <- paste(output, collapse = "\n\n")
+    output <- gsub(output,
+                   pattern = "|\n\n", replacement = "|\n", fixed = TRUE)
+  }
+  output
+}
+
+format_md.codebookEntry <- function(x, name = "", add_lines = TRUE, ...) {
+  blank_line <- "\n"
+  horizontal_line <- if (add_lines) "\n---\n" else NULL
+  
+  annot <- x@annotation
+  stats <- x@stats
+  
+  title <- paste0("`", name, "`", " --- ", "'", annot["description"], "'")
+  wording <- if (!is.na(annot["wording"])) paste0("\"", annot["wording"], "\"") else NULL
+  knit_spec <- knit_array(x@spec)
+  knit_tab <- if (!is.null(stats$tab)) knit_tab(stats$tab) else NULL
+  knit_descr <- if (!is.null(stats$descr)) knit_array(stats$descr) else NULL
+  remark <- paste0("Remark: ", annot["Remark"])
+  
+  output <- c(horizontal_line,
+              title,
+              wording,
+              horizontal_line,
+              knit_spec,
+              blank_line,
+              knit_tab,
+              knit_descr,
+              remark,
+              blank_line
+  )
+  
+  output <- output[!sapply(output, is.null)]
+}
+
+knit_array <- function (x) {
+  if (!is.matrix(x)) x <- as.matrix(x)
+  df <- data.frame(names = rownames(x), content = unname(x))
+  colnames(df) <- NULL
+  knit_result <- c(knitr::kable(df, format = "simple"))
+  knit_result <- knit_result[-c(1, length(knit_result))]
+  knit_result <- c(knit_result)
+}
+
+knit_tab <- function (x) {
+  tab <- data.frame(x[,,1])
+  tab <- cbind(rownames(tab), tab)
+  rownames(tab) <- NULL
+  colnames(tab)[1] <- "Values and labels"
+  knit_counts <- c(knitr::kable(tab))
+}

--- a/pkg/R/importer-methods.R
+++ b/pkg/R/importer-methods.R
@@ -149,7 +149,7 @@ subset.importer <- function (x, subset, select, drop = FALSE,
         nl <- as.list(1:nvars)
         names(nl) <- names
         cols <- logical(nvars)
-        if (class(substitute(select)) == 'call') {
+        if (is.call(substitute(select))) {
             cols[eval(substitute(select), nl, parent.frame())] <- TRUE
             select.vars <- sapply(substitute(select)[-1],as.character)
         } else { # As suggested by Diogo Ferrari (https://dioferrari.com/)

--- a/pkg/man/format_md.Rd
+++ b/pkg/man/format_md.Rd
@@ -1,0 +1,104 @@
+\name{format_md}
+\alias{format_md}
+\alias{format_md.codebook}
+\alias{format_md.codebookEntry}
+\title{
+  Format Codebooks as Markdown
+}
+\description{
+ \code{format_md} is for showing objects in a convenient way in Markdown format. Can be included to Rmarkdown file with the \code{cat()} function and the \code{results='asis'} code block option. The following example should be runned in a Rmd file with different output formats.
+}
+\usage{
+\method{format_md}{codebook}(x, unlist = TRUE, collapse = TRUE, ...)
+\method{format_md}{codebookEntry}(x, name = "", add_lines = TRUE, ...)
+}
+\arguments{
+  \item{x}{a "codebook" or "codebookEntry" object}
+  \item{unlist}{a boolean; if false one list per item with the Markdown output}
+  \item{collapse}{a boolean; if false one element for each line}
+  \item{name}{a string; the variable name}
+  \item{add_lines}{a boolean; if true adds a lines before and after the title}
+  \item{\dots}{further arguments, passed to other functions}
+  }
+\value{
+   \code{format_md} character string with code suitable for inclusion into a Markdown-file.
+}
+\examples{
+\dontrun{
+ ---
+ title: "Title"
+ author: "Author"
+ date: "01/01/2000"
+ output: html_document
+ ---
+
+ ## The table can be formated with knitr::kable options
+   
+ ```{r setup, include=FALSE}
+ library(memisc)
+ opts <- options(knitr.kable.NA = "", digits = 2)
+ ```
+ 
+ ```{r, include=FALSE}
+ Data1 <- data.set(
+   vote = sample(c(1,2,3,8,9,97,99),size=300,replace=TRUE),
+   region = sample(c(rep(1,3),rep(2,2),3,99),size=300,replace=TRUE),
+   income = exp(rnorm(300,sd=.7))*2000
+ )
+ 
+ Data1 <- within(Data1,{
+   description(vote) <- "Vote intention"
+   description(region) <- "Region of residence"
+   description(income) <- "Household income"
+   foreach(x=c(vote,region),{
+     measurement(x) <- "nominal"
+   })
+   measurement(income) <- "ratio"
+   labels(vote) <- c(
+     Conservatives         =  1,
+     Labour                =  2,
+     "Liberal Democrats"   =  3,
+     "Don't know"          =  8,
+     "Answer refused"      =  9,
+     "Not applicable"      = 97,
+     "Not asked in survey" = 99)
+   labels(region) <- c(
+     England               =  1,
+     Scotland              =  2,
+     Wales                 =  3,
+     "Not applicable"      = 97,
+     "Not asked in survey" = 99)
+   foreach(x=c(vote,region,income),{
+     annotation(x)["Remark"] <- "This is not a real survey item, of course ..."
+   })
+   missing.values(vote) <- c(8,9,97,99)
+   missing.values(region) <- c(97,99)
+ })
+ 
+ ```
+ 
+ ## Codebook
+ 
+ ```{r cars, echo=FALSE, results='asis'}
+ 
+ codebook_data <- codebook(Data1)
+ 
+ codebook_md <- format_md(codebook_data, digits = 2)
+ 
+ cat(codebook_md, sep = "\n")
+ 
+ ```
+
+ ## Codebook without the vote variable
+ 
+ ```{r cars, echo=FALSE, results='asis'}
+ 
+ codebook_md2 <- format_md(codebook_data, digits = 2, unlist = FALSE)
+
+ codebook_md2[["vote"]] <- NULL
+ 
+ cat(codebook_md2, sep = "\n")
+ 
+ ```
+  }
+}


### PR DESCRIPTION
## What ?
I have added functions to create outputs which can be included in Rmarkdown files and exported in different formats.
## Why ?
With these functions, the memisc codebook can be included in a larger document with, for example, a presentation of the database and references. This document can be exported to html format, similarly to format_html, but also to pdf and word formats.
## How ?
I created a S3-generic function 'format_md()' and codebook and codebookEntry methods which return text in Markdown format. The documentation includes a Rmarkdown example showing how the codebook can be included in a larger document. It works with html, pdf and word output formats.
## Testing
I checked the result with devtool::check() and there is no issue.