### PR TITLE
update 'format_md.codebook()' method for prettier output in all formats

### DIFF
--- a/pkg/R/codebook-format-md.R
+++ b/pkg/R/codebook-format-md.R
@@ -1,19 +1,11 @@
 format_md.codebook <- function(x, unlist = TRUE, collapse = TRUE, ...) {
-  output <- mapply(format_md, x = x@.Data, name = names(x),
+  out <- mapply(format_md, x = x@.Data, name = names(x),
                    MoreArgs = list(...))
-  names(output) <- names(x)
-  if (unlist) output <- unlist(output)
-  if (collapse && is.list(output)) {
-    output <- lapply(output, paste, collapse = "\n\n")
-    output <- lapply(output, gsub, 
-                     pattern = "|\n\n", replacement = "|\n", fixed = TRUE)
-  }
-  if (collapse && !is.list(output)) {
-    output <- paste(output, collapse = "\n\n")
-    output <- gsub(output,
-                   pattern = "|\n\n", replacement = "|\n", fixed = TRUE)
-  }
-  output
+  names(out) <- names(x)
+  if (unlist) out <- unlist(out)
+  if (collapse && is.list(out)) out <- lapply(out, paste, collapse = "  \n")
+  if (collapse && !is.list(out)) out <- paste(out, collapse = "  \n")
+  out
 }
 
 format_md.codebookEntry <- function(x, name = "", add_lines = TRUE, ...) {
@@ -38,6 +30,7 @@ format_md.codebookEntry <- function(x, name = "", add_lines = TRUE, ...) {
               blank_line,
               knit_tab,
               knit_descr,
+              blank_line,
               remark,
               blank_line
   )

--- a/pkg/R/codebook-format-md.R
+++ b/pkg/R/codebook-format-md.R
@@ -49,8 +49,14 @@ knit_array <- function (x) {
 
 knit_tab <- function (x) {
   tab <- data.frame(x[,,1])
-  tab <- cbind(rownames(tab), tab)
+  row_names <- rownames(tab)
+  values <- regmatches(row_names, regexpr(row_names, pattern = "^[ ]*[0-9]+"))
+  values <- as.numeric(values)
+  missing_value <- grepl(rownames(tab), pattern = " M '")
+  missing_value <- ifelse(missing_value, "M", "")
+  labels <- regmatches(row_names, regexpr(row_names, pattern = "'.*'"))
+  tab <- cbind(values, missing_value, labels, tab)
   rownames(tab) <- NULL
-  colnames(tab)[1] <- "Values and labels"
+  colnames(tab) <- c("", "", "Values and labels", "N", "Valid", "Total")
   knit_counts <- c(knitr::kable(tab))
 }


### PR DESCRIPTION
## What ?
Update the 'format_md.codebook()' method for prettier output for the different formats.

## Why ?
The single linebreak is ignored in the pdf output. I used a double linebreak to handle this issue but the output has a large line space between lines. I replace this double linebreak by a solution from https://gist.github.com/shaunlebron/746476e6e7a4d698b373.
The values and labels in the stats table were all merged, for prettier output we split it.

## How ?
I replace linebreak "\n\n" by "  \n" for prettier output in the different format. I split the values and labels in three colunms with missing values.

## Testing
No issue with devtools::check().

## Other comments
I changed variable name for shorter code.